### PR TITLE
Feat - shortcuts, workspace support and open current block   

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,15 +6,19 @@ Open and edit Logseq pages and config files in VS Code
 
 
 ### Usage
+Default shortcuts 
 - open graph: `mod+shift+o`
 - open current page: `mod+o` 
- 
-Notice Logseq already provides a keybinding `ctrl+d ctrl+a` which opens current page in default app.
-(Personally, I need one more shortcut because I use nvim as default app for markdown while still vscode is used sometimes.)  
+- open current block: `mod+alt+o`  
+
+Or type names in the command palette to see corresponding commands.
+
+Notice also a existent keybinding `ctrl+d ctrl+a` in Logseq which opens current page in default app.
  
 Any application, as long as it supports url scheme, could be added as an option. Feel free to tweak `generateUrl` function in `src/App.vue`.
 
 ### Development
 
-- `npm install && npm run build` in terminal to install dependencies.
+- `npm install` in terminal to install dependencies.
+- `npm run build` or `npm run watch` to build. 
 - `Load unpacked plugin` in Logseq Desktop client.

--- a/README.md
+++ b/README.md
@@ -4,6 +4,16 @@ Open and edit Logseq pages and config files in VS Code
 
 ![demo](./demo.gif)
 
+
+### Usage
+- open graph: `mod+shift+o`
+- open current page: `mod+o` 
+ 
+Notice Logseq already provides a keybinding `ctrl+d ctrl+a` which opens current page in default app.
+(Personally, I need one more shortcut because I use nvim as default app for markdown while still vscode is used sometimes.)  
+ 
+Any application, as long as it supports url scheme, could be added as an option. Feel free to tweak `generateUrl` function in `src/App.vue`.
+
 ### Development
 
 - `npm install && npm run build` in terminal to install dependencies.

--- a/README.md
+++ b/README.md
@@ -1,26 +1,59 @@
 ## Open Logseq in VS Code
 
-Open and edit Logseq pages and config files in VS Code
+This plugin offers quick access of following in VS Code 
+- focused blocks or pages
+- configuration files
+- the graph folder
 
 ![demo](./demo.gif)
 
+VS Codium is also supported.
+ 
+## Usage
 
-## How to Use
+Use the following keyboard shortcuts:
+- `mod+shift+o`: Open graph
+- `mod+o`: Open current page
+- `mod+alt+o`: Open current block
 
-The application provides default keyboard shortcuts for ease of use:
-- To open the graph, use `mod+shift+o`.
-- To open the current page, use `mod+o`.
-- To open the current block, use `mod+alt+o`.
+You can also use the command palette to execute these commands.
 
-Alternatively, you can enter the command names in the command palette to execute the corresponding commands.
+Note: Logseq's `ctrl+d ctrl+a` shortcut opens the current page in the default app.
 
-Please note that Logseq has an existing keybinding `ctrl+d ctrl+a` which opens the current page in the default app.
+## Options
+### Editor Options
+Specify the version of VS Code (or, URL scheme) you're using. 
+- Stable : `vscode://file/`
+- Insider : `vscode-insiders://file/`
+- VS Codium : `vscodium://file/`
 
-Not just vscode, it is possible to open in any application that uses URL schemes. In the source code, you can modify the `generateUrl` function in `src/App.vue` to add more applications.
+Though not planed, this list can potentially be extended to other editors that support file URLs.
 
-## Development Instructions
+### Window options
+By default, a new windows will be opened. But sometimes it's preferable to avoid reopening a new windows for each file. So several options are provided.
 
-To set up the development environment:
-- Run `npm install` in the terminal to install the necessary dependencies.
-- Use `npm run build` or `npm run watch` to build the application.
-- Use the `Load unpacked plugin` option in the Logseq Desktop client to load the plugin.
+Choose where to open the specified file
+- In an independent new window
+- In the last focused window
+- In the graph folder
+- In the workspace (Experimental function. It only works when the file `<graph folder>/<graph_name>.code-workspace` exists. And it's only tested with the stable version)
+
+> Right now the path of the file `<graph_name>.code-workspace` has to be put in the graph folder. And it's highly recommended to enable automatic saving on focus change. 
+> ```json
+>{
+>	"folders": [
+>		{
+>			"path": "."
+>		}
+>	],
+>	"settings": {
+>		"files.autoSave": "onFocusChange", // recommended
+>	}
+>}
+> ```
+
+## Development
+
+- Install dependencies with `npm install`
+- Build the application using `npm run build` or `npm run watch`
+- Load the plugin in the Logseq Desktop client using the `Load unpacked plugin` option.

--- a/README.md
+++ b/README.md
@@ -5,20 +5,22 @@ Open and edit Logseq pages and config files in VS Code
 ![demo](./demo.gif)
 
 
-### Usage
-Default shortcuts 
-- open graph: `mod+shift+o`
-- open current page: `mod+o` 
-- open current block: `mod+alt+o`  
+## How to Use
 
-Or type names in the command palette to see corresponding commands.
+The application provides default keyboard shortcuts for ease of use:
+- To open the graph, use `mod+shift+o`.
+- To open the current page, use `mod+o`.
+- To open the current block, use `mod+alt+o`.
 
-Notice also a existent keybinding `ctrl+d ctrl+a` in Logseq which opens current page in default app.
- 
-Any application, as long as it supports url scheme, could be added as an option. Feel free to tweak `generateUrl` function in `src/App.vue`.
+Alternatively, you can enter the command names in the command palette to execute the corresponding commands.
 
-### Development
+Please note that Logseq has an existing keybinding `ctrl+d ctrl+a` which opens the current page in the default app.
 
-- `npm install` in terminal to install dependencies.
-- `npm run build` or `npm run watch` to build. 
-- `Load unpacked plugin` in Logseq Desktop client.
+Not just vscode, it is possible to open in any application that uses URL schemes. In the source code, you can modify the `generateUrl` function in `src/App.vue` to add more applications.
+
+## Development Instructions
+
+To set up the development environment:
+- Run `npm install` in the terminal to install the necessary dependencies.
+- Use `npm run build` or `npm run watch` to build the application.
+- Use the `Load unpacked plugin` option in the Logseq Desktop client to load the plugin.

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "author": "rebornix",
   "scripts": {
     "dev": "vite",
-    "build": "vite build"
+    "build": "vite build",
+    "watch": "vite build --watch"
   },
   "dependencies": {
     "@popperjs/core": "^2.9.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "logseq-open-in-code",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "main": "dist/index.html",
   "author": "rebornix",
   "scripts": {

--- a/src/App.vue
+++ b/src/App.vue
@@ -24,10 +24,7 @@ function generateUrl(path, line_num = 0, new_window = true) {
 
   const windowId = new_window ? "?windowId=_blank" : "";
 
-  // TODO remove in the next version of vscode 1.84.0
-  const _path = encodeURIComponent(path).replace((/^\/*/g), "");
-
-  return `${protocol}://file/` + _path + line + windowId;
+  return `${protocol}://file/` + path + line + windowId;
 }
 
 async function openConfig(name) {

--- a/src/App.vue
+++ b/src/App.vue
@@ -1,14 +1,6 @@
 <template>
-  <div
-    class="container-wrap"
-    v-bind:class="{ lspdark: opts.isDark }"
-    @click="_onClickOutside"
-  >
-    <div
-      class="container-inner shadow-lg"
-      v-if="ready"
-      :style="{ left: left + 'px', top: top + 'px' }"
-    >
+  <div class="container-wrap" v-bind:class="{ lspdark: opts.isDark }" @click="_onClickOutside">
+    <div class="container-inner shadow-lg" v-if="ready" :style="{ left: left + 'px', top: top + 'px' }">
       <div class="_opener" v-if="currentPage" @click="_onClickOpenCurrentPage">
         Edit current page
       </div>
@@ -24,7 +16,7 @@
 <script>
 function generateUrl(path) {
   const { distro } = logseq.settings;
-  const protocol = distro === "stable" ? "vscode" : "vscode-insiders";
+  const protocol = distro === "stable" ? "vscode" : distro === "insiders" ? "vscode-insiders" : "vscodium";
   return `${protocol}://file/` + encodeURIComponent(path) + "?windowId=_blank";
 }
 

--- a/src/App.vue
+++ b/src/App.vue
@@ -41,9 +41,13 @@ function if_new_window() {
   return (logseq.settings.window.includes("new"));
 }
 
-async function openGraph() {
+async function getGraph() {
   const graph = await logseq.App.getCurrentGraph();
-  window.open(generateUrl(graph.url.replace("logseq_local_", ""), 0, true));
+  return graph.url.replace("logseq_local_", "");
+}
+
+async function openGraph() {
+  window.open(generateUrl(await getGraph(), 0, true));
 }
 
 async function getAncestorPageOfCurrentBlock() {

--- a/src/App.vue
+++ b/src/App.vue
@@ -46,8 +46,25 @@ async function getGraph() {
   return graph.url.replace("logseq_local_", "");
 }
 
-async function openGraph() {
+async function getGraphWorkspace() {
+  const graph = await logseq.App.getCurrentGraph();
+  return graph.url.replace("logseq_local_", "") + `/${graph.name}.code-workspace`;
+}
+
+async function openGraphFolder() {
   window.open(generateUrl(await getGraph(), 0, true));
+}
+
+async function openGraphAsWorkspace() {
+  window.open(generateUrl(await getGraphWorkspace(), 0, true));
+}
+
+async function openGraph() {
+  if (logseq.settings.workspace == 'folder') {
+    await openGraphFolder();
+  } else {
+    await openGraphAsWorkspace();
+  }
 }
 
 async function getAncestorPageOfCurrentBlock() {

--- a/src/App.vue
+++ b/src/App.vue
@@ -46,6 +46,8 @@ async function getAnsetorPageOfCurrentBlock() {
 }
 
 async function findFile(fileId) {
+  const graph = await logseq.App.getCurrentGraph();
+
   const matches = await logseq.DB.datascriptQuery(
     `[:find ?file
                 :where
@@ -55,7 +57,7 @@ async function findFile(fileId) {
   );
 
   if (matches && matches.length > 0) {
-    const file = matches[0][0];
+    const file = graph.url.replace("logseq_local_", "") + "/" + matches[0][0];
     return file;
   } else {
     return null;

--- a/src/App.vue
+++ b/src/App.vue
@@ -177,9 +177,20 @@ async function openCurrentLine() {
   }
 
   for (let index = 0; index < all_blocks.length; index++) {
+    if (index === 0) {
+      // if the first block is a property block, trim it and count lines
+      let first_block = all_blocks[0].content.trim().split('\n');
+      if (first_block[0].includes("::")) {
+        count += first_block.length + 1;
+        continue;
+      }
+    }
     const block = all_blocks[index];
     let subcount = count_line_in_block(block, curb, true);
     count += subcount.lineCount
+    if (__debug) {
+      console.log("level 0", index, count);
+    }
     if (subcount.hasLine) {
       break;
     }

--- a/src/App.vue
+++ b/src/App.vue
@@ -168,12 +168,18 @@ async function openCurrentLine() {
 
   let count = 0;
   let curb = await logseq.Editor.getCurrentBlock();
-  let all_blocks = await logseq.Editor.getCurrentPageBlocksTree();
+  if (__debug) {
+    console.log("current block", curb);
+  }
+  // let all_blocks = await logseq.Editor.getCurrentPageBlocksTree();
 
-  if (all_blocks.length === 1 && !('content' in all_blocks[0])) {
-    // It seems possible to get a page by name but not id. Strange
-    const page = await logseq.Editor.getPage(curb?.page.id);
-    all_blocks = await logseq.Editor.getPageBlocksTree(page.name);
+  // if (all_blocks.length === 1 && !('content' in all_blocks[0])) {
+  // It seems possible to get a page by name but not id. Strange
+  const page = await logseq.Editor.getPage(curb?.page.id);
+  let all_blocks = await logseq.Editor.getPageBlocksTree(page.name);
+  // }
+  if (__debug) {
+    console.log(all_blocks);
   }
 
   for (let index = 0; index < all_blocks.length; index++) {

--- a/src/App.vue
+++ b/src/App.vue
@@ -71,16 +71,15 @@ async function findFile(fileId) {
 }
 
 async function openPageLineInVSCode(line_number) {
-  const currentPage = await logseq.Editor.getCurrentPage();
-  if (currentPage && currentPage.file) {
-    const fileId = currentPage.file.id;
-    const file = await findFile(fileId);
-
-    if (file) {
-      window.open(generateUrl(file, line_number, if_new_window()));
-      return;
-    }
-  }
+  // const currentPage = await logseq.Editor.getCurrentPage();
+  // if (currentPage && currentPage.file) {
+  //   const fileId = currentPage.file.id;
+  //   const file = await findFile(fileId);
+  //   if (file) {
+  //     window.open(generateUrl(file, line_number, if_new_window()));
+  //     return;
+  //   }
+  // }
 
   const ansetor = await getAncestorPageOfCurrentBlock();
   if (ansetor) {

--- a/src/App.vue
+++ b/src/App.vue
@@ -24,8 +24,10 @@ function generateUrl(path, line_num = 0, new_window = true) {
 
   const windowId = new_window ? "?windowId=_blank" : "";
 
+  // TODO remove in the next version of vscode 1.84.0
+  const _path = encodeURIComponent(path).replace((/^\/*/g), "");
 
-  return `${protocol}://file/` + encodeURIComponent(path) + line + windowId;
+  return `${protocol}://file/` + _path + line + windowId;
 }
 
 async function openConfig(name) {

--- a/src/App.vue
+++ b/src/App.vue
@@ -90,6 +90,30 @@ async function openPageInVSCode() {
   }
 }
 
+async function registerShortcuts() {
+  logseq.App.registerCommandPalette({
+    key: `Open_current_page_in_default_editor`,
+    label: "Open current page in default editor",
+    keybinding: {
+      binding: logseq.settings.key_open_page,
+      mode: "global",
+    }
+  },
+    openPageInVSCode
+  );
+
+  logseq.App.registerCommandPalette({
+    key: `Open_graph_folder_in_default_editor`,
+    label: "Open graph folder in default editor",
+    keybinding: {
+      binding: logseq.settings.key_open_graph,
+      mode: "global",
+    }
+  },
+    openGraph
+  );
+}
+
 export default {
   name: "App",
 
@@ -148,6 +172,8 @@ export default {
     });
 
     checkCurrentPage();
+
+    registerShortcuts();
   },
 
   methods: {

--- a/src/main.js
+++ b/src/main.js
@@ -113,5 +113,20 @@ logseq
     default: 'stable',
     enumChoices: ['stable', 'insiders'],
     enumPicker: 'select'
-  }])
+  },
+  {
+    key: 'key_open_page',
+    type: 'string',
+    title: 'Shortcut: open current page',
+    description: 'Shorcut to open the current page in VS Code (default `ctrl+o`)',
+    default: 'mod+o',
+  },
+  {
+    key: 'key_open_graph',
+    type: 'string',
+    title: 'Shortcut: open graph folder',
+    description: 'Shorcut to open graph folder in VS Code (default `ctrl+shift+o`)',
+    default: 'mod+shift+o',
+  }],
+  )
   .ready(createModel()).then(main)

--- a/src/main.js
+++ b/src/main.js
@@ -108,7 +108,7 @@ logseq
   .useSettingsSchema([{
     key: 'distro',
     type: 'enum',
-    title: 'URL Schema',
+    title: 'URL Scheme',
     description: 'Open the files in either VS Code Stable, Insiders or VS Codium',
     default: 'stable',
     enumChoices: ['stable', 'insiders', 'vs codium'],
@@ -118,14 +118,14 @@ logseq
     key: 'key_open_page',
     type: 'string',
     title: 'Shortcut: open current page',
-    description: 'Shorcut to open the current page in VS Code (default `ctrl+o`)',
+    description: 'Shortcut to open the current page in VS Code (default `ctrl+o`)',
     default: 'mod+o',
   },
   {
     key: 'key_open_graph',
     type: 'string',
     title: 'Shortcut: open graph folder',
-    description: 'Shorcut to open graph folder in VS Code (default `ctrl+shift+o`)',
+    description: 'Shortcut to open graph folder in VS Code (default `ctrl+shift+o`)',
     default: 'mod+shift+o',
   }],
   )

--- a/src/main.js
+++ b/src/main.js
@@ -119,7 +119,7 @@ logseq
     title: 'VS Code Window',
     description: 'Where do you want to open the page?',
     default: 'stable',
-    enumChoices: ['Always in a new window', 'In the graph folder or workspace', 'Reuse the last active window'],
+    enumChoices: ['Always in a new window', 'Reuse the last active window', 'In the graph folder', 'In the graph folder (as workspace)'],
     enumPicker: 'select'
   },
   {
@@ -142,14 +142,4 @@ logseq
     title: 'Shortcut: open current graph',
     description: 'Shortcut to open the current graph in VS Code (default `ctrl+shift+o`)',
     default: 'mod+shift+o',
-  }, {
-    key: 'workspace',
-    type: 'enum',
-    title: 'open workspace',
-    description: 'Open graph as folder or VSCode workspace. If you choose VSCode workspace, you need to create a workspace file `<graph_name>.code-workspace` in the graph folder.',
-    default: 'folder',
-    enumChoices: ['folder', 'VSCode workspace'],
-    enumPicker: 'select'
-  }],
-  )
-  .ready(createModel()).then(main)
+  }]).ready(createModel()).then(main)

--- a/src/main.js
+++ b/src/main.js
@@ -108,10 +108,10 @@ logseq
   .useSettingsSchema([{
     key: 'distro',
     type: 'enum',
-    title: 'VS Code distro',
-    description: 'Open the files in either VS Code Stable or Insiders',
+    title: 'URL Schema',
+    description: 'Open the files in either VS Code Stable, Insiders or VS Codium',
     default: 'stable',
-    enumChoices: ['stable', 'insiders'],
+    enumChoices: ['stable', 'insiders', 'vs codium'],
     enumPicker: 'select'
   },
   {

--- a/src/main.js
+++ b/src/main.js
@@ -117,9 +117,9 @@ logseq
     key: 'window',
     type: 'enum',
     title: 'VS Code Window',
-    description: 'Open pages in which VS Code window?',
+    description: 'Where do you want to open the page?',
     default: 'stable',
-    enumChoices: ['Open a new window', 'In the graph folder', 'Reuse last active window'],
+    enumChoices: ['Always in a new window', 'In the graph folder or workspace', 'Reuse the last active window'],
     enumPicker: 'select'
   },
   {

--- a/src/main.js
+++ b/src/main.js
@@ -113,6 +113,14 @@ logseq
     default: 'stable',
     enumChoices: ['stable', 'insiders', 'vs codium'],
     enumPicker: 'select'
+  }, {
+    key: 'window',
+    type: 'enum',
+    title: 'VS Code Window',
+    description: 'Open pages in which VS Code window?',
+    default: 'stable',
+    enumChoices: ['Open a new window', 'In the graph folder', 'Reuse last active window'],
+    enumPicker: 'select'
   },
   {
     key: 'key_open_line',

--- a/src/main.js
+++ b/src/main.js
@@ -115,6 +115,13 @@ logseq
     enumPicker: 'select'
   },
   {
+    key: 'key_open_line',
+    type: 'string',
+    title: 'Shortcut: open current line',
+    description: 'Shortcut to open the current line in VS Code (default `ctrl+alt+o`)',
+    default: 'mod+alt+o',
+  },
+  {
     key: 'key_open_page',
     type: 'string',
     title: 'Shortcut: open current page',

--- a/src/main.js
+++ b/src/main.js
@@ -139,9 +139,17 @@ logseq
   {
     key: 'key_open_graph',
     type: 'string',
-    title: 'Shortcut: open graph folder',
-    description: 'Shortcut to open graph folder in VS Code (default `ctrl+shift+o`)',
+    title: 'Shortcut: open current graph',
+    description: 'Shortcut to open the current graph in VS Code (default `ctrl+shift+o`)',
     default: 'mod+shift+o',
+  }, {
+    key: 'workspace',
+    type: 'enum',
+    title: 'open workspace',
+    description: 'Open graph as folder or VSCode workspace. If you choose VSCode workspace, you need to create a workspace file `<graph_name>.code-workspace` in the graph folder.',
+    default: 'folder',
+    enumChoices: ['folder', 'VSCode workspace'],
+    enumPicker: 'select'
   }],
   )
   .ready(createModel()).then(main)


### PR DESCRIPTION
Thanks to the great potential of the plugin, this PR brings you what comes really handy if you frequently switch between VS Code and Logseq.

- Open the current block (implemented by opening the page to certain line)
- Open in the same VS Code instance (under the graph folder or workspace)
- Support VS Codium
- Shortcuts and customization

I have updated readme to explain these changes. 

PS: This PR is based on #8